### PR TITLE
Fixed typo

### DIFF
--- a/bitwrk/account.go
+++ b/bitwrk/account.go
@@ -413,7 +413,7 @@ func validateCurrency(currency *money.Currency, otherCurrency money.Currency) (*
 // into the op argument (-2: <, -1: <=, 0: =, 1: >=, 2: >). Any other value panicks.
 func checkFlowDirection(msg string, op int, val int64) error {
 	if op < -2 || op > 2 {
-		panic(fmt.Sprintf("op paramter must be -2 <= op <= 2  (was: %v)", op))
+		panic(fmt.Sprintf("op parameter must be -2 <= op <= 2  (was: %v)", op))
 	}
 	rel := []string{"<", "<=", "=", ">=", ">"}[op+2]
 	if op < 0 && val < 0 || op >= -1 && op <= 1 && val == 0 || op > 0 && val > 0 {


### PR DESCRIPTION
Simple, nit-picky typo fix: "parameter"